### PR TITLE
Win lose in place 🎌

### DIFF
--- a/gd4_sfml_tcp_game/Application.cpp
+++ b/gd4_sfml_tcp_game/Application.cpp
@@ -10,19 +10,26 @@
 
 const sf::Time Application::kTimePerFrame = sf::seconds(1.f/60.f);
 
-Application::Application() :m_window(sf::VideoMode(1024, 768), "Networked", sf::Style::Close)
-, m_key_binding_1(1), m_key_binding_2(2)
-, m_stack(State::Context(m_window, m_textures, m_fonts, m_music, m_sound, m_key_binding_1, m_key_binding_2))
+Application::Application()
+	: m_window(sf::VideoMode(1024, 768), "Networked", sf::Style::Close)
+	, m_key_binding_1(1)
+	, m_key_binding_2(2)
+	, m_player1(nullptr, 1, &m_key_binding_1)
+	, m_context(m_window, m_textures, m_fonts, m_music, m_sound, m_key_binding_1, m_key_binding_2)
+	, m_stack(m_context)
 {
+	m_context.player = &m_player1;
 	m_window.setKeyRepeatEnabled(false);
+
 	m_fonts.Load(Font::kMain, "Media/Fonts/Super-Mario-World.ttf");
 	m_textures.Load(TextureID::kTitleScreen, "Media/Textures/SpiritQuestBackground.png");
 	m_textures.Load(TextureID::kButtonNormal, "Media/Textures/32x32 Blue Bubble Buttons/Blank Buttons/Blue_Button_01.png");
 	m_textures.Load(TextureID::kButtonSelected, "Media/Textures/32x32 Blue Bubble Buttons/Blank Buttons/Blue_Button_02.png");
 	m_textures.Load(TextureID::kButtonActivated, "Media/Textures/32x32 Blue Bubble Buttons/Blank Buttons/Blue_Button_03.png");
 	m_textures.Load(TextureID::kButtons, "Media/Textures/BlueButtons.png");
-	m_textures.Load(TextureID::kSettingsBackground, "Media/Textures/Clouds 3/1.png");//ET
+	m_textures.Load(TextureID::kSettingsBackground, "Media/Textures/Clouds 3/1.png");
 	m_textures.Load(TextureID::kSettingsHeader, "Media/Textures/32x32 Blue Bubble Buttons/Buttons With Text/Text_Settings_Button_021.png");
+
 	RegisterStates();
 	m_stack.PushState(StateID::kTitle);
 }

--- a/gd4_sfml_tcp_game/Application.hpp
+++ b/gd4_sfml_tcp_game/Application.hpp
@@ -23,19 +23,22 @@ private:
 
 private:
 	sf::RenderWindow m_window;
-	//Player m_player;
+	Player m_player1;
 	//Player m_player2;// et // second player
 
 	TextureHolder m_textures;
 	FontHolder m_fonts;
 
-	StateStack m_stack;
-	static const sf::Time kTimePerFrame;
+	
 
 	MusicPlayer m_music;
 	SoundPlayer m_sound;
 
 	KeyBinding m_key_binding_1;
 	KeyBinding m_key_binding_2;
+
+	State::Context m_context;      
+	StateStack m_stack;
+	static const sf::Time kTimePerFrame;
 };
 

--- a/gd4_sfml_tcp_game/GameOverState.cpp
+++ b/gd4_sfml_tcp_game/GameOverState.cpp
@@ -18,23 +18,11 @@ GameOverState::GameOverState(StateStack& stack, Context context, const std::stri
 
     if (context.player->GetMissionStatus() == MissionStatus::kMissionSuccessGhostFL)
     {
-        m_game_over_text.setString("The Ghost Team has escaped the Reaper! \n \n          Player 1 wins");
+        m_game_over_text.setString("The Ghosts have escaped the Reapers! \n \n         The Ghosts Win ");
     }
     else if (context.player->GetMissionStatus() == MissionStatus::kMissionSuccessReaperCG)
     {
-        m_game_over_text.setString("The Reaper Team has reaped the Ghosts! \n \n           Player 2 wins");
-    }
-    else if (context.player->GetMissionStatus() == MissionStatus::kMissionSuccessGhostRD)
-    {
-        m_game_over_text.setString("The Reapers were Defeated! \n \n        Player 1 wins");
-    }
-    else if (context.player->GetMissionStatus() == MissionStatus::kMissionSuccessReaperGD)
-    {
-        m_game_over_text.setString("The Ghosts were Defeated! \n \n         Player 2 wins");
-    }
-    else if (context.player->GetMissionStatus() == MissionStatus::kMissionFailureReaper)
-    {
-        m_game_over_text.setString("The Reapers has Failed! \n \n         Player 1 wins");
+        m_game_over_text.setString("The Reaper Team has reaped the Ghosts! \n \n           The Reapers Win");
     }
     else
     {

--- a/gd4_sfml_tcp_game/GameState.cpp
+++ b/gd4_sfml_tcp_game/GameState.cpp
@@ -9,8 +9,10 @@ GameState::GameState(StateStack& stack, Context context)
 	m_world(*context.window, *context.fonts, *context.sounds, false),
 	m_player(nullptr, 1, context.keys1)  
 {
+	context.player = &m_player; 
 	m_world.AddCharacter(1);  // add the character separately
 	m_player.SetMissionStatus(MissionStatus::kMissionRunning);
+	
 	//Play Music
 	context.music->Play(MusicThemes::kMissionTheme);
 }
@@ -22,8 +24,9 @@ void GameState::Draw()
 
 bool GameState::Update(sf::Time dt)
 {
+	
 
-	m_world.Update(dt);
+	/*
 	if (!m_world.HasAlivePlayer())
 	{
 		m_player.SetMissionStatus(MissionStatus::kMissionSuccessReaperGD);
@@ -52,7 +55,23 @@ bool GameState::Update(sf::Time dt)
 		//m_player2.SetMissionStatus(MissionStatus::kMissionFailureReaper);
 		RequestStackPush(StateID::kGameOver);
 	}
-	
+	*/	
+	m_world.Update(dt);
+	int ghostCount = m_world.CountCharacters(CharacterType::kGhost);
+	int reaperCount = m_world.CountCharacters(CharacterType::kReaper);
+	bool ghostReachedFinish = m_world.HasPlayerReachedEnd();
+
+	if (ghostCount == 0 && reaperCount > 0)
+	{
+		GetContext().player->SetMissionStatus(MissionStatus::kMissionSuccessReaperCG);
+		RequestStackPush(StateID::kGameOver);
+	}
+	else if (ghostReachedFinish || reaperCount == 0)
+	{
+		GetContext().player->SetMissionStatus(MissionStatus::kMissionSuccessGhostFL);
+		RequestStackPush(StateID::kGameOver);
+	}
+
 	
 	CommandQueue& commands = m_world.GetCommandQueue();
 	m_player.HandleRealTimeInput(commands);

--- a/gd4_sfml_tcp_game/StateStack.cpp
+++ b/gd4_sfml_tcp_game/StateStack.cpp
@@ -5,7 +5,7 @@
 #include <SFML/Window/Event.hpp>
 #include <cassert>
 
-StateStack::StateStack(State::Context context) : m_context(context)
+StateStack::StateStack(State::Context& context) : m_context(context)
 {
 }
 

--- a/gd4_sfml_tcp_game/StateStack.hpp
+++ b/gd4_sfml_tcp_game/StateStack.hpp
@@ -13,7 +13,7 @@
 class StateStack : private sf::NonCopyable
 {
 public:
-	explicit StateStack(State::Context context);
+	explicit StateStack(State::Context& context);
 	template<typename T>
 	void RegisterState(StateID state_id);
 	template <typename T, typename Param1>
@@ -43,7 +43,7 @@ private:
 private:
 	std::vector<State::Ptr> m_stack;
 	std::vector<PendingChange> m_pending_list;
-	State::Context m_context;
+	State::Context& m_context;
 	std::map<StateID, std::function<State::Ptr()>> m_state_factory;
 };
 

--- a/gd4_sfml_tcp_game/World.cpp
+++ b/gd4_sfml_tcp_game/World.cpp
@@ -587,3 +587,15 @@ void World::UpdateSounds()
 	// Remove unused sounds
 	m_sounds.RemoveStoppedSounds();
 }
+
+//ET
+int World::CountCharacters(CharacterType type) const
+{
+	return std::count_if(m_player_aircraft.begin(), m_player_aircraft.end(),
+		[type](Character* c)
+		{
+			return !c->IsMarkedForRemoval() &&
+				((type == CharacterType::kGhost && c->IsGhost()) ||
+					(type == CharacterType::kReaper && c->IsReaper()));
+		});
+}

--- a/gd4_sfml_tcp_game/World.hpp
+++ b/gd4_sfml_tcp_game/World.hpp
@@ -44,6 +44,8 @@ public:
 	Character* GetCharacter(int identifier) const;
 	sf::FloatRect GetBattleFieldBounds() const;
 	bool PollGameAction(GameActions::Action& out);
+	int CountCharacters(CharacterType type) const;
+	
 
 private:
 	void LoadTextures();


### PR DESCRIPTION
Premature win and lose occur when testing alone but the game now doesn't crash at get_mission_status when played. Changes made count the players in game with a function. Constraints for winning and losing changed, bug fixed with adding player and changes to the stack in Application